### PR TITLE
Use sh instead of bash for better portability

### DIFF
--- a/bin/mbzextract
+++ b/bin/mbzextract
@@ -1,2 +1,2 @@
-#!/usr/bin/env bash
+#!/bin/sh
 env python3 -m mbzextract.mbzextract "$@"


### PR DESCRIPTION
Some systems (e.g. FreeBSD base) don't come with `bash`, but as far as I know, most if not all Unix-like systems [have `/bin/sh` present](https://serverfault.com/a/865880). This commit would use `sh` instead of `bash` to launch the program.